### PR TITLE
fix(RocketQADualEncoder): fix manifest keywords

### DIFF
--- a/examples/jina_example/rocketqa_encoder/manifest.yml
+++ b/examples/jina_example/rocketqa_encoder/manifest.yml
@@ -1,5 +1,5 @@
 manifest_version: 1
 name: RocketQADualEncoder
 description: `RocketQADualEncoder` calculates the `embedding` of the passages and questions with RocketQA Dual-Encoder models.
-keywords: qa, text, PaddlePaddle, en, zh, encoder, rocketqa, marco
+keywords: [qa, text, PaddlePaddle, en, zh, encoder, rocketqa, marco]
 url: https://github.com/PaddlePaddle/RocketQA/tree/main/examples/jina_example/rocketqa_encoder


### PR DESCRIPTION
`keywords` should be an array instead of a string.